### PR TITLE
Add configurable preferredRegions support

### DIFF
--- a/src/main/java/org/example/Configuration.java
+++ b/src/main/java/org/example/Configuration.java
@@ -92,6 +92,9 @@ public class Configuration {
     @Parameter(names = "-isThinClientEnabled", description = "A boolean parameter to indicate whether the thin client is enabled.", arity = 1)
     private boolean isThinClientEnabled = false;
 
+    @Parameter(names = "-preferredRegions", description = "Comma-separated list of preferred regions (e.g., 'North Central US,West US'). If not set, all regions are auto-discovered from the account.")
+    private String preferredRegions = "";
+
     public String getConfigFile() {
         return this.configFile;
     }
@@ -271,6 +274,14 @@ public class Configuration {
 
     public void setShouldHaveE2ETimeoutForWrites(boolean value) {
         this.shouldHaveE2ETimeoutForWrites = value;
+    }
+
+    public String getPreferredRegions() {
+        return this.preferredRegions;
+    }
+
+    public void setPreferredRegions(String preferredRegions) {
+        this.preferredRegions = preferredRegions;
     }
 
 

--- a/src/main/java/org/example/JsonConfigurationLoader.java
+++ b/src/main/java/org/example/JsonConfigurationLoader.java
@@ -106,6 +106,9 @@ public class JsonConfigurationLoader {
         if (root.has("isThinClientEnabled")) {
             config.setThinClientEnabled(root.get("isThinClientEnabled").asBoolean());
         }
+        if (root.has("preferredRegions")) {
+            config.setPreferredRegions(root.get("preferredRegions").asText());
+        }
 
         logger.info("Configuration loaded from JSON file successfully");
     }

--- a/src/main/java/org/example/Utils.java
+++ b/src/main/java/org/example/Utils.java
@@ -20,6 +20,14 @@ public class Utils {
 
     public static List<String> getPreferredRegions(Configuration configuration) {
 
+        // Use explicitly configured preferred regions if provided
+        if (configuration.getPreferredRegions() != null && !configuration.getPreferredRegions().isEmpty()) {
+            return Arrays.stream(configuration.getPreferredRegions().split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(java.util.stream.Collectors.toList());
+        }
+
         String documentEndpoint = configuration.getAccountHost().isEmpty() ? TestConfigurations.HOST : configuration.getAccountHost();
         String masterKey = configuration.getAccountMasterKey().isEmpty() ? TestConfigurations.MASTER_KEY : configuration.getAccountMasterKey();
 


### PR DESCRIPTION
## Summary

Adds a preferredRegions configuration option (JSON config + CLI arg) so drills can target specific regions instead of always auto-discovering all regions from the account.

## Changes

- **Configuration.java** -- new `preferredRegions` field (comma-separated string, e.g. `North Central US,West US`)
- **JsonConfigurationLoader.java** -- reads `preferredRegions` from JSON config
- **Utils.java** -- uses configured regions when set; falls back to auto-discovery when empty

## Usage

**JSON config:**
```json
{
  "preferredRegions": "North Central US"
}
```

**CLI arg:**
```
-preferredRegions "North Central US,West US"
```

## Motivation

For PPAF DR drills, we need to test with a single preferred region (the primary write region) to validate failover behavior. Previously, preferred regions were always auto-discovered from the account, returning all regions.