### PR TITLE
Add configurable preferredRegions support

### DIFF
--- a/src/main/java/com/azure/cosmos/ppaf/config/Configuration.java
+++ b/src/main/java/com/azure/cosmos/ppaf/config/Configuration.java
@@ -125,6 +125,10 @@ public class Configuration {
     @JsonProperty("readConsistencyStrategy")
     private ReadConsistencyStrategy readConsistencyStrategy = null;
 
+    @Parameter(names = "-preferredRegions", description = "Comma-separated list of preferred regions (e.g., 'North Central US,West US'). If not set, all regions are auto-discovered from the account.")
+    @JsonProperty("preferredRegions")
+    private String preferredRegions = "";
+
     public static Configuration fromJsonFile(String filePath) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
@@ -317,6 +321,14 @@ public class Configuration {
 
     public void setShouldHaveE2ETimeoutForWrites(boolean value) {
         this.shouldHaveE2ETimeoutForWrites = value;
+    }
+
+    public String getPreferredRegions() {
+        return this.preferredRegions;
+    }
+
+    public void setPreferredRegions(String preferredRegions) {
+        this.preferredRegions = preferredRegions;
     }
 
 

--- a/src/main/java/com/azure/cosmos/ppaf/config/JsonConfigurationLoader.java
+++ b/src/main/java/com/azure/cosmos/ppaf/config/JsonConfigurationLoader.java
@@ -111,6 +111,9 @@ public class JsonConfigurationLoader {
             String strategy = root.get("readConsistencyStrategy").asText().toUpperCase(Locale.ROOT).replace(" ", "_").trim();
             config.setReadConsistencyStrategy(ReadConsistencyStrategy.valueOf(strategy));
         }
+        if (root.has("preferredRegions")) {
+            config.setPreferredRegions(root.get("preferredRegions").asText());
+        }
 
         logger.info("Configuration loaded from JSON file successfully");
     }

--- a/src/main/java/com/azure/cosmos/ppaf/util/Utils.java
+++ b/src/main/java/com/azure/cosmos/ppaf/util/Utils.java
@@ -20,6 +20,14 @@ public class Utils {
 
     public static List<String> getPreferredRegions(Configuration configuration) {
 
+        // Use explicitly configured preferred regions if provided
+        if (configuration.getPreferredRegions() != null && !configuration.getPreferredRegions().isEmpty()) {
+            return Arrays.stream(configuration.getPreferredRegions().split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(java.util.stream.Collectors.toList());
+        }
+
         String documentEndpoint = configuration.getAccountHost().isEmpty() ? TestConfigurations.HOST : configuration.getAccountHost();
         String masterKey = configuration.getAccountMasterKey().isEmpty() ? TestConfigurations.MASTER_KEY : configuration.getAccountMasterKey();
 


### PR DESCRIPTION
## Summary

Adds a `preferredRegions` configuration option (JSON config, Jackson deserialization, and CLI arg) so drills can target specific regions instead of always auto-discovering all regions from the account.

## Changes

- **Configuration.java** -- new `preferredRegions` field with `@JsonProperty` annotation, getter/setter, and CLI parameter
- **JsonConfigurationLoader.java** -- reads `preferredRegions` from JSON config (legacy loader path)
- **Utils.java** -- `getPreferredRegions()` checks configured regions first; parses comma-separated string into `List<String>`; falls back to auto-discovery when empty

## Wiring to CosmosClient

Both workloads call `Utils.getPreferredRegions(cfg)` and pass the result to `CosmosClientBuilder.preferredRegions()`:

- `PPAFDrillWorkload`: line 71 -> line 99
- `PPAFForSessionConsistencyWorkload`: line 148-149 -> line 70

## Usage

**JSON config:**
```json
{
  "preferredRegions": "North Central US"
}
```

**CLI arg:**
```
-preferredRegions "North Central US,West US"
```

## Motivation

For PPAF DR drills, we need to test with a single preferred region (the primary write region) to validate failover behavior. Previously, preferred regions were always auto-discovered from the account, returning all regions.

Rebased on latest master (post package refactor to `com.azure.cosmos.ppaf`).